### PR TITLE
Fix issue #1 by adding app.UseGlobalExceptionHandler() extension method

### DIFF
--- a/src/AndcultureCode.CSharp.Web/AndcultureCode.CSharp.Web.csproj
+++ b/src/AndcultureCode.CSharp.Web/AndcultureCode.CSharp.Web.csproj
@@ -12,4 +12,12 @@
     <Version>0.0.1</Version>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="AndcultureCode.CSharp.Core" Version="0.2.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/AndcultureCode.CSharp.Web/Extensions/IApplicationBuilderExtensions.cs
+++ b/src/AndcultureCode.CSharp.Web/Extensions/IApplicationBuilderExtensions.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
+using System.Net;
+
+namespace AndcultureCode.CSharp.Web.Extensions
+{
+    public static class IApplicationBuilderExtensions
+    {
+        /// <summary>
+        /// Configure dotnet core API to wrap unhandled exceptions in IResult<Error>
+        /// and respond with json
+        /// </summary>
+        public static void UseGlobalExceptionHandler(this IApplicationBuilder app)
+        {
+            app.UseExceptionHandler(appError =>
+                appError.Run(async context =>
+                {
+                    context.Response.ContentType = "application/json";
+                    context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+
+                    var contextFeature = context.Features.Get<IExceptionHandlerFeature>();
+                    var result = contextFeature.ToResult();
+                    if (result == null)
+                    {
+                        return;
+                    }
+
+                    await context.Response.WriteAsync(JsonConvert.SerializeObject(result));
+                })
+            );
+        }
+    }
+}

--- a/src/AndcultureCode.CSharp.Web/Extensions/IApplicationBuilderExtensions.cs
+++ b/src/AndcultureCode.CSharp.Web/Extensions/IApplicationBuilderExtensions.cs
@@ -9,7 +9,7 @@ namespace AndcultureCode.CSharp.Web.Extensions
     public static class IApplicationBuilderExtensions
     {
         /// <summary>
-        /// Configure dotnet core API to wrap unhandled exceptions in IResult<Error>
+        /// Configure dotnet core API to wrap unhandled exceptions in IResult<>
         /// and respond with json
         /// </summary>
         public static void UseGlobalExceptionHandler(this IApplicationBuilder app)

--- a/src/AndcultureCode.CSharp.Web/Extensions/IExceptionHandlerFeatureExtensions.cs
+++ b/src/AndcultureCode.CSharp.Web/Extensions/IExceptionHandlerFeatureExtensions.cs
@@ -1,0 +1,24 @@
+using AndcultureCode.CSharp.Core.Interfaces;
+using AndcultureCode.CSharp.Core.Models;
+using Microsoft.AspNetCore.Diagnostics;
+
+namespace AndcultureCode.CSharp.Web.Extensions
+{
+    public static class IExceptionHandlerFeatureExtensions
+    {
+        /// <summary>
+        /// Transform exception context feature to IResult<object>
+        /// </summary>
+        public static IResult<object> ToResult(this IExceptionHandlerFeature feature)
+        {
+            if (feature?.Error == null)
+            {
+                return null;
+            }
+
+            var exception = feature.Error;
+
+            return new Result<object>(exception.GetType().Name, exception.ToString());
+        }
+    }
+}

--- a/test/AndcultureCode.CSharp.Web.Tests/AndcultureCode.CSharp.Web.Tests.csproj
+++ b/test/AndcultureCode.CSharp.Web.Tests/AndcultureCode.CSharp.Web.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AndcultureCode.CSharp.Testing" Version="0.2.1" />
     <PackageReference Include="coverlet.msbuild" Version="2.6.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/AndcultureCode.CSharp.Web.Tests/Extensions/IExceptionHandlerFeatureExtensionsTest.cs
+++ b/test/AndcultureCode.CSharp.Web.Tests/Extensions/IExceptionHandlerFeatureExtensionsTest.cs
@@ -18,7 +18,6 @@ namespace AndcultureCode.CSharp.Web.Tests.Unit.Extensions
 
         #endregion Setup
 
-
         #region ToResult
 
         [Fact]

--- a/test/AndcultureCode.CSharp.Web.Tests/Extensions/IExceptionHandlerFeatureExtensionsTest.cs
+++ b/test/AndcultureCode.CSharp.Web.Tests/Extensions/IExceptionHandlerFeatureExtensionsTest.cs
@@ -8,7 +8,7 @@ using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace AndcultureCode.CSharp.Core.Tests.Unit.Extensions
+namespace AndcultureCode.CSharp.Web.Tests.Unit.Extensions
 {
     public class IExceptionHandlerFeatureExtensionsTest : BaseUnitTest
     {
@@ -30,11 +30,7 @@ namespace AndcultureCode.CSharp.Core.Tests.Unit.Extensions
         [Fact]
         public void ToResult_When_Feature_Error_Is_Null_Returns_Null()
         {
-            // Arrange
-            var feature = Mock.Of<IExceptionHandlerFeature>();
-
-            // Act & Assert
-            IExceptionHandlerFeatureExtensions.ToResult(feature).ShouldBeNull();
+            Mock.Of<IExceptionHandlerFeature>().ToResult().ShouldBeNull();
         }
 
         [Fact]
@@ -45,7 +41,7 @@ namespace AndcultureCode.CSharp.Core.Tests.Unit.Extensions
             var feature = Mock.Of<IExceptionHandlerFeature>(m => m.Error == expected);
 
             // Act
-            var result = IExceptionHandlerFeatureExtensions.ToResult(feature);
+            var result = feature.ToResult();
 
             // Assert
             result.ShouldNotBeNull();

--- a/test/AndcultureCode.CSharp.Web.Tests/Extensions/IExceptionHandlerFeatureExtensionsTest.cs
+++ b/test/AndcultureCode.CSharp.Web.Tests/Extensions/IExceptionHandlerFeatureExtensionsTest.cs
@@ -1,0 +1,57 @@
+using System;
+using AndcultureCode.CSharp.Testing.Extensions;
+using AndcultureCode.CSharp.Testing.Tests;
+using AndcultureCode.CSharp.Web.Extensions;
+using Microsoft.AspNetCore.Diagnostics;
+using Moq;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AndcultureCode.CSharp.Core.Tests.Unit.Extensions
+{
+    public class IExceptionHandlerFeatureExtensionsTest : BaseUnitTest
+    {
+        #region Setup
+
+        public IExceptionHandlerFeatureExtensionsTest(ITestOutputHelper output) : base(output) { }
+
+        #endregion Setup
+
+
+        #region ToResult
+
+        [Fact]
+        public void ToResult_When_Feature_Is_Null_Returns_Null()
+        {
+            IExceptionHandlerFeatureExtensions.ToResult(feature: null).ShouldBeNull();
+        }
+
+        [Fact]
+        public void ToResult_When_Feature_Error_Is_Null_Returns_Null()
+        {
+            // Arrange
+            var feature = Mock.Of<IExceptionHandlerFeature>();
+
+            // Act & Assert
+            IExceptionHandlerFeatureExtensions.ToResult(feature).ShouldBeNull();
+        }
+
+        [Fact]
+        public void ToResult_When_Feature_Error_Set_Returns_Result()
+        {
+            // Arrange
+            var expected = new Exception(Random.String());
+            var feature = Mock.Of<IExceptionHandlerFeature>(m => m.Error == expected);
+
+            // Act
+            var result = IExceptionHandlerFeatureExtensions.ToResult(feature);
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.ShouldHaveErrorsFor(expected.GetType().Name, exactCount: 1, containedInMessage: expected.Message);
+        }
+
+        #endregion ToResult
+    }
+}


### PR DESCRIPTION
Fix issue #1 by adding extension methods to create result from IExceptionHandlerFeature as well as configure the IApplicationBuilder

Now applications just import the extension and call a single method to configure their application

```csharp
using AndcultureCode.CSharp.Web.Extensions;

app.UseGlobalExceptionHandler();
```