### PR TITLE
Update Controller to use ErrorConstants value from Core

### DIFF
--- a/src/AndcultureCode.CSharp.Web/AndcultureCode.CSharp.Web.csproj
+++ b/src/AndcultureCode.CSharp.Web/AndcultureCode.CSharp.Web.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AndcultureCode.CSharp.Core" Version="0.5.10" />
+    <PackageReference Include="AndcultureCode.CSharp.Core" Version="0.7.0" />
     <PackageReference Include="AndcultureCode.CSharp.Extensions" Version="0.4.5" />
     <PackageReference Include="AutoMapper" Version="9.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0" />

--- a/src/AndcultureCode.CSharp.Web/Controllers/Controller.cs
+++ b/src/AndcultureCode.CSharp.Web/Controllers/Controller.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using AndcultureCode.CSharp.Core.Constants;
 using AndcultureCode.CSharp.Core.Enumerations;
 using AndcultureCode.CSharp.Core.Interfaces;
-using AndcultureCode.CSharp.Core.Models;
 using AndcultureCode.CSharp.Extensions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -14,7 +13,7 @@ using AndcultureCode.CSharp.Core.Utilities.Localization;
 using AndcultureCode.CSharp.Web.Interfaces;
 using Microsoft.AspNetCore.Localization;
 using AndcultureCode.CSharp.Web.Extensions;
-using Microsoft.Net.Http.Headers;
+using AndcultureCode.CSharp.Core.Models.Errors;
 
 namespace AndcultureCode.CSharp.Web.Controllers
 {
@@ -33,7 +32,7 @@ namespace AndcultureCode.CSharp.Web.Controllers
         /// <summary>
         /// Requested resource was not found
         /// </summary>
-        public const string ERROR_RESOURCE_NOT_FOUND = "Web.Controller.ERROR_RESOURCE_NOT_FOUND";
+        public const string ERROR_RESOURCE_NOT_FOUND = ErrorConstants.ERROR_RESOURCE_NOT_FOUND_KEY;
 
         #endregion Constants
 

--- a/src/AndcultureCode.CSharp.Web/Cultures/AndcultureCode.CSharp.Web.en-US.json
+++ b/src/AndcultureCode.CSharp.Web/Cultures/AndcultureCode.CSharp.Web.en-US.json
@@ -1,10 +1,10 @@
 [
     {
-        "Key": "Web.Controller.ERROR_ID_MISMATCH",
-        "Value": "A route parameter '{0}' does not match the related '{1}' property on the DTO."
+        "Key": "ERROR_RESOURCE_NOT_FOUND",
+        "Value": "The resource or related resource {0} that was requested was not found."
     },
     {
-        "Key": "Web.Controller.ERROR_RESOURCE_NOT_FOUND",
-        "Value": "The resource or related resource {0} that was requested was not found."
+        "Key": "Web.Controller.ERROR_ID_MISMATCH",
+        "Value": "A route parameter '{0}' does not match the related '{1}' property on the DTO."
     }
 ]

--- a/src/AndcultureCode.CSharp.Web/Cultures/AndcultureCode.CSharp.Web.es-ES.json
+++ b/src/AndcultureCode.CSharp.Web/Cultures/AndcultureCode.CSharp.Web.es-ES.json
@@ -1,10 +1,10 @@
 [
     {
-        "Key": "Web.Controller.ERROR_ID_MISMATCH",
+        "Key": "ERROR_RESOURCE_NOT_FOUND",
         "Value": ""
     },
     {
-        "Key": "Web.Controller.ERROR_RESOURCE_NOT_FOUND",
+        "Key": "Web.Controller.ERROR_ID_MISMATCH",
         "Value": ""
     }
 ]

--- a/src/AndcultureCode.CSharp.Web/Extensions/IExceptionHandlerFeatureExtensions.cs
+++ b/src/AndcultureCode.CSharp.Web/Extensions/IExceptionHandlerFeatureExtensions.cs
@@ -1,5 +1,5 @@
 using AndcultureCode.CSharp.Core.Interfaces;
-using AndcultureCode.CSharp.Core.Models;
+using AndcultureCode.CSharp.Core.Models.Errors;
 using Microsoft.AspNetCore.Diagnostics;
 
 namespace AndcultureCode.CSharp.Web.Extensions


### PR DESCRIPTION
Updated AndcultureCode.CSharp.Core -> 0.7.0, update namespace changes, swap ERROR_RESOURCE_NOT_FOUND with error constant from core

Closes #14 

- [x] Related GitHub issue(s) linked in PR description
- [x] Destination branch merged, built and tested with your changes
- [x] Code formatted and follows best practices and patterns
- [x] Code builds cleanly (no _additional_ warnings or errors)
- [-] Manually tested
- [x] Automated tests are passing
- [x] No _decreases_ in automated test coverage
- [-] Documentation updated (readme, docs, comments, etc.)
- [x] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
